### PR TITLE
fixed bug after django 1.8 upgrade

### DIFF
--- a/mail_templated/__init__.py
+++ b/mail_templated/__init__.py
@@ -43,7 +43,7 @@ class EmailMessage(mail.EmailMultiAlternatives):
         self._template = value
         # Prepare template blocks to not search them each time we send
         # a message.
-        for block in self._template.nodelist:
+        for block in self._template.template.nodelist:
             # We are interested in BlockNodes only. Ignore another elements.
             if isinstance(block, BlockNode):
                 if block.name == 'subject':


### PR DESCRIPTION
Templates engine was [changed](https://docs.djangoproject.com/en/1.8/topics/templates/) in **django 1.8**.

So, EmailMessage class returned error 'AttributeError':

```
 File "/project/env/local/lib/python2.7/site-packages/mail_templated/__init__.py", line 41, in template
    for block in self._template.nodelist:
AttributeError: 'Template' object has no attribute 'nodelist'
```