### PR TITLE
Fix for 'NoneType' object has no attribute 'engine' error Django 1.8

### DIFF
--- a/mail_templated/__init__.py
+++ b/mail_templated/__init__.py
@@ -57,6 +57,7 @@ class EmailMessage(mail.EmailMultiAlternatives):
         """Render email with the current context and send it"""
         # Prepare context
         context = Context(self.context)
+        context.template = self._template.template
         # Assume the subject may be set manually.
         if self._subject is not None:
             self.subject = self._subject.render(context).strip('\n\r')

--- a/mail_templated/message.py
+++ b/mail_templated/message.py
@@ -54,6 +54,7 @@ class EmailMessage(mail.EmailMultiAlternatives):
         """Render email with the current context and send it"""
         # Prepare context
         context = Context(self.context)
+        context.template = self.template
         # Assume the subject may be set manually.
         if self._subject is not None:
             self.subject = self._subject.render(context).strip('\n\r')

--- a/mail_templated/templates/mail_templated_test/multilang.html
+++ b/mail_templated/templates/mail_templated_test/multilang.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+{% block subject %}
+Hello {{ name }}
+{% endblock %}
+
+{% block body %}
+{% blocktrans with user_name=name %}
+{{ user_name }}, this is a plain text part.
+{% endblocktrans %}
+{% endblock %}
+
+{% block html %}
+{% blocktrans with user_name=name %}
+{{ user_name }}, this is an html part.
+{% endblocktrans %}
+{% endblock %}

--- a/mail_templated/tests.py
+++ b/mail_templated/tests.py
@@ -1,5 +1,6 @@
 from django.core import mail
 from django.test import TestCase
+from django.utils import translation
 
 from . import send_mail
 
@@ -41,6 +42,22 @@ class SendMailTestCase(TestCase):
         self.assertEqual(message.alternatives[0][0],
                          'User, this is an html part.')
         self.assertEqual(message.alternatives[0][1], 'text/html')
+
+    def test_multilang(self):
+        translation.activate('en')
+        send_mail(
+            'mail_templated_test/multilang.html', {'name': 'User'},
+            'from@inter.net', ['to@inter.net'])
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertEqual(message.subject, 'Hello User')
+        self.assertEqual(message.body,
+                         'User, this is a plain text part.')
+        self.assertEqual(len(message.alternatives), 1)
+        self.assertEqual(message.alternatives[0][0],
+                         'User, this is an html part.')
+        self.assertEqual(message.alternatives[0][1], 'text/html')
+        translation.deactivate()
 
     def test_alternatives(self):
         send_mail(


### PR DESCRIPTION
When used with the latest version of Django 1.8 may come to a case where the context.template is NoneType because it is not set when we render the template nodes separately from the whole template. 

This in my case having a blocktrans block in the template caused the error: 

> File "/.virtualenvs/myenv/local/lib/python2.7/site-packages/django/templatetags/i18n.py", line 152, in render
    default_value = context.template.engine.string_if_invalid
AttributeError: 'NoneType' object has no attribute 'engine'

