### PR TITLE
get_template incompatibility on django 1.8

### DIFF
--- a/mail_templated/__init__.py
+++ b/mail_templated/__init__.py
@@ -31,8 +31,15 @@ class EmailMessage(mail.EmailMultiAlternatives):
     @template_name.setter
     def template_name(self, value):
         self._template_name = value
+
         # Load the template.
-        self.template = get_template(self._template_name)
+        # In Django 1.7 get_template() returned a django.template.Template.
+        # In Django 1.8 it returns a django.template.backends.django.Template.
+        template = get_template(self._template_name)
+        try:
+            self.template = template.template
+        except AttributeError:
+            self.template = template
 
     @property
     def template(self):


### PR DESCRIPTION
Update the package to can be use also with django 1.8.