### PR TITLE
Don't HTML escape the text parts

### DIFF
--- a/mail_templated/templates/mail_templated/base.tpl
+++ b/mail_templated/templates/mail_templated/base.tpl
@@ -1,5 +1,5 @@
-{{ TAG_START_SUBJECT }}{% block subject %}{% endblock %}{{ TAG_END_SUBJECT }}
+{{ TAG_START_SUBJECT }}{% autoescape off %}{% block subject %}{% endblock %}{% endautoescape %}{{ TAG_END_SUBJECT }}
 
-{{ TAG_START_BODY }}{% block body %}{% endblock %}{{ TAG_END_BODY }}
+{{ TAG_START_BODY }}{% autoescape off %}{% block body %}{% endblock %}{% endautoescape %}{{ TAG_END_BODY }}
 
 {{ TAG_START_HTML }}{% block html %}{% endblock %}{{ TAG_END_HTML }}


### PR DESCRIPTION
Currently it HTML escapes special characters in the subject and plain text parts of the message template. This fixes that.

PS: Hi Artem! I hope you and your family are well?